### PR TITLE
Fix vertical preview not capping with new topic composer

### DIFF
--- a/about.json
+++ b/about.json
@@ -5,7 +5,7 @@
   "about_url": "https://github.com/Alteras1/discourse-editor-preview-position",
   "license_url": "https://github.com/Alteras1/discourse-editor-preview-position/blob/main/LICENSE",
   "learn_more": "Add a dropdown in the composer that let's users choose where the preview is positioned. Only works in desktop view.",
-  "theme_version": "1.0.1",
+  "theme_version": "1.0.2",
   "minimum_discourse_version": "3.2.0.beta2",
   "maximum_discourse_version": null,
   "assets": {

--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -241,6 +241,7 @@
     }
     .d-editor-preview-wrapper {
       flex: var(--composer-preview-flex, 1 1 0);
+      flex-shrink: 1;
     }
   }
 }
@@ -260,5 +261,12 @@
     .d-editor-container
     .d-editor-preview-wrapper {
     height: clamp(15%, var(--composer-preview-height, calc(50% - 16px)), 85%);
+  }
+  #reply-control .with-tags .title-input {
+    flex: 1 1 100%;
+    min-width: 100%;
+    #reply-title {
+      max-width: 100%;
+    }
   }
 }


### PR DESCRIPTION
Fixes an issue where the height of the preview in the top position wasn't getting capped due to the new topic fields.

see https://meta.discourse.org/t/editor-preview-position/309934/3